### PR TITLE
Fix fout in de volgorde van verwerken.

### DIFF
--- a/Website/Meldingen/MailStorage.cs
+++ b/Website/Meldingen/MailStorage.cs
@@ -161,7 +161,7 @@ namespace Meldingen
                 bijlage.Mimetype = GetMimeType(fileAttachment);
                 bijlage.Inhoud = new System.Data.Linq.Binary(fileAttachment.Content);
             }
-            if (bijlage.Melding.BijlageContents.Count(b => b.IsPrimaireFoto) == 0)
+            if ((bijlage.Melding.Latitude ?? 0m) == 0 || (bijlage.Melding.Longitude ?? 0m) == 0)
             {
                 try
                 {


### PR DESCRIPTION
HIerdoor kan het voorkomen dat voor een melding met meerdere bijlagen het coordinaat  niet op de melding wordt gezet
ook al heeft een van de foto's wel een coordinaat.